### PR TITLE
refactor: implement multi-group CPU detection and affinity handling

### DIFF
--- a/src/system/cpu/backend/amd.rs
+++ b/src/system/cpu/backend/amd.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::system::{
-    affinity::GroupAffinity, cpu::backend::CpuBackend, kernal_driver::KernelDriver,
+    cpu::{backend::CpuBackend, group_affinity::GroupAffinity},
+    kernal_driver::KernelDriver,
 };
 
 #[derive(Debug)]

--- a/src/system/cpu/backend/intel.rs
+++ b/src/system/cpu/backend/intel.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use x86::msr::IA32_PACKAGE_THERM_STATUS;
 
 use crate::system::{
-    affinity::GroupAffinity, cpu::backend::CpuBackend, kernal_driver::KernelDriver,
+    cpu::{backend::CpuBackend, group_affinity::GroupAffinity},
+    kernal_driver::KernelDriver,
 };
 
 #[derive(Debug)]

--- a/src/system/cpu/backend/mod.rs
+++ b/src/system/cpu/backend/mod.rs
@@ -1,4 +1,4 @@
-use crate::system::affinity::GroupAffinity;
+use crate::system::cpu::group_affinity::GroupAffinity;
 
 pub mod amd;
 pub mod intel;

--- a/src/system/cpu/backend/unknown.rs
+++ b/src/system/cpu/backend/unknown.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::system::{
-    affinity::GroupAffinity, cpu::backend::CpuBackend, kernal_driver::KernelDriver,
+    cpu::{backend::CpuBackend, group_affinity::GroupAffinity},
+    kernal_driver::KernelDriver,
 };
 
 #[derive(Debug)]

--- a/src/system/cpu/core.rs
+++ b/src/system/cpu/core.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use crate::system::cpu::{backend::CpuBackend, thread::Thread};
+
+pub struct Core {
+    backend: Arc<dyn CpuBackend + Send + Sync>,
+    pub core_id: u32,
+    pub threads: Vec<Thread>,
+}
+
+impl Core {
+    pub fn new(core_id: u32, backend: Arc<dyn CpuBackend + Send + Sync>) -> Self {
+        Self {
+            backend,
+            core_id,
+            threads: Vec::new(), // start empty
+        }
+    }
+
+    pub fn temperature(&self) -> Option<f32> {
+        self.backend.read_core_temp(self.core_id)
+    }
+}
+
+impl std::fmt::Debug for Core {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Core")
+            .field("core_id", &self.core_id)
+            .field("threads", &self.threads)
+            .finish()
+    }
+}

--- a/src/system/cpu/cpu.rs
+++ b/src/system/cpu/cpu.rs
@@ -1,55 +1,18 @@
-use std::{sync::Arc, thread};
+use std::sync::Arc;
 
-use raw_cpuid::{CpuId, CpuIdReader, ExtendedTopologyLevel, TopologyType};
+use raw_cpuid::{CpuId, CpuIdReader};
 
 use crate::system::{
-    affinity::{get_all_group_affinities, run_on_all_affinities, GroupAffinity},
-    cpu::backend::{amd::AmdBackend, intel::IntelBackend, unknown::UnknownBackend, CpuBackend},
+    cpu::{
+        backend::{amd::AmdBackend, intel::IntelBackend, unknown::UnknownBackend, CpuBackend},
+        core::Core,
+        group_affinity::{get_all_group_affinities, run_on_all_affinities, GroupAffinity},
+        thread::Thread,
+        topology::{get_legacy_info, get_topology_info},
+        vendor::{get_vendor, Vendor},
+    },
     kernal_driver::KernelDriver,
 };
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Vendor {
-    Intel,
-    Amd,
-    Unknown(Option<String>),
-}
-
-pub struct Thread {
-    pub thread_id: u32,
-    pub affinity: GroupAffinity,
-    backend: Arc<dyn CpuBackend + Send + Sync>,
-}
-
-impl std::fmt::Debug for Thread {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Thread")
-            .field("thread_id", &self.thread_id)
-            .field("affinity", &self.affinity)
-            .finish()
-    }
-}
-
-pub struct Core {
-    backend: Arc<dyn CpuBackend + Send + Sync>,
-    pub core_id: u32,
-    pub threads: Vec<Thread>,
-}
-
-impl Core {
-    pub fn temperature(&self) -> Option<f32> {
-        self.backend.read_core_temp(self.core_id)
-    }
-}
-
-impl std::fmt::Debug for Core {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Core")
-            .field("core_id", &self.core_id)
-            .field("threads", &self.threads)
-            .finish()
-    }
-}
 
 pub struct Cpu {
     backend: Arc<dyn CpuBackend + Send + Sync>,
@@ -82,69 +45,37 @@ impl std::fmt::Debug for Cpu {
     }
 }
 
-fn cpuid_bits_needed(count: u8) -> u8 {
-    let mut mask: u8 = 0x80;
-    let mut cnt: u8 = 8;
-
-    while (cnt > 0) && ((mask & count) != mask) {
-        mask >>= 1;
-        cnt -= 1;
-    }
-
-    cnt
-}
-
 pub fn gather_cpus(driver: &Arc<KernelDriver>) -> Result<Vec<Cpu>, String> {
     let affinities = get_all_group_affinities()?;
-    // println!("{:#?}", affinities);
-    let mut cpus: Vec<Cpu> = Vec::new();
+    let mut cpus = Vec::new();
 
-    // Run detection on all cores in parallel
     let results = run_on_all_affinities(affinities, |affinity| detect_cpu(affinity))?;
-
     for (affinity, info) in results {
         insert_cpu_info(&mut cpus, affinity, info?, driver);
     }
 
-    // println!("{:#?}", cpus);
-
     Ok(cpus)
 }
 
-// Detect CPU topology and info for a single logical core
 fn detect_cpu(
-    aff: GroupAffinity,
+    affinity: GroupAffinity,
 ) -> (
     GroupAffinity,
     Result<(u32, u32, u32, Vendor, String), String>,
 ) {
     let cpuid = CpuId::new();
-
     let vendor = get_vendor(&cpuid);
     let model = get_model(&cpuid);
 
-    let res = if let Some(topoiter) = cpuid.get_extended_topology_info() {
+    let info = if let Some(topoiter) = cpuid.get_extended_topology_info() {
         get_topology_info(topoiter, vendor, &model)
     } else {
         get_legacy_info(&cpuid, vendor, &model)
     };
 
-    (aff, res)
+    (affinity, info)
 }
 
-// Extract vendor from CPUID
-fn get_vendor<R: CpuIdReader>(cpuid: &CpuId<R>) -> Vendor {
-    cpuid
-        .get_vendor_info()
-        .map(|v| match v.as_str() {
-            "GenuineIntel" => Vendor::Intel,
-            "AuthenticAMD" | "HygonGenuine" => Vendor::Amd,
-            name => Vendor::Unknown(Some(name.to_owned())),
-        })
-        .unwrap_or(Vendor::Unknown(None))
-}
-
-// Extract model string from CPUID
 fn get_model<R: CpuIdReader>(cpuid: &CpuId<R>) -> String {
     cpuid
         .get_processor_brand_string()
@@ -152,169 +83,50 @@ fn get_model<R: CpuIdReader>(cpuid: &CpuId<R>) -> String {
         .unwrap_or_default()
 }
 
-// Handle extended topology (x2APIC)
-fn get_topology_info(
-    topoiter: impl Iterator<Item = ExtendedTopologyLevel>,
-    vendor: Vendor,
-    model: &str,
-) -> Result<(u32, u32, u32, Vendor, String), String> {
-    let topology: Vec<ExtendedTopologyLevel> = topoiter.collect();
-
-    let mut smt_x2apic_shift = 0;
-    let mut core_x2apic_shift = 0;
-
-    for level in &topology {
-        match level.level_type() {
-            TopologyType::SMT => smt_x2apic_shift = level.shift_right_for_next_apic_id(),
-            TopologyType::Core => core_x2apic_shift = level.shift_right_for_next_apic_id(),
-            _ => return Err("Unsupported topology level type".to_string()),
-        }
-    }
-
-    // Use the first element of the topology vector for x2apic_id
-    let x2apic_id = topology.first().map(|l| l.x2apic_id()).unwrap_or(0);
-
-    let smt_select_mask = !(u32::max_value() << smt_x2apic_shift);
-    let core_select_mask = (!((u32::max_value()) << core_x2apic_shift)) ^ smt_select_mask;
-    let pkg_select_mask = u32::max_value() << core_x2apic_shift;
-
-    let smt_id = x2apic_id & smt_select_mask;
-    let core_id = (x2apic_id & core_select_mask) >> smt_x2apic_shift;
-    let pkg_id = (x2apic_id & pkg_select_mask) >> core_x2apic_shift;
-
-    println!(
-        "x2APIC#{} (pkg: {}, core: {}, smt: {})",
-        x2apic_id, pkg_id, core_id, smt_id
-    );
-
-    Ok((pkg_id, core_id, smt_id, vendor, model.to_string()))
-}
-
-// Handle legacy APIC topology
-fn get_legacy_info<R: CpuIdReader>(
-    cpuid: &CpuId<R>,
-    vendor: Vendor,
-    model: &str,
-) -> Result<(u32, u32, u32, Vendor, String), String> {
-    let (max_logical_processor_ids, smt_max_cores_for_package) = match vendor {
-        Vendor::Intel => {
-            let cparams = cpuid
-                .get_cache_parameters()
-                .ok_or("Intel CPU: missing cache parameters")?;
-            let max_logical = cpuid
-                .get_feature_info()
-                .map(|f| f.max_logical_processor_ids())
-                .unwrap_or(1);
-            let smt_cores = cparams
-                .into_iter()
-                .next()
-                .ok_or("Intel CPU: no cache parameter entries")?
-                .max_cores_for_package() as u8;
-            (max_logical as u8, smt_cores)
-        }
-        Vendor::Amd => {
-            let info = cpuid
-                .get_processor_capacity_feature_info()
-                .ok_or("AMD CPU: missing processor capacity info")?;
-            (info.num_phys_threads() as u8, info.apic_id_size() as u8)
-        }
-        Vendor::Unknown(_) => return Err("Unsupported CPU vendor".to_string()),
-    };
-
-    let smt_mask_width = cpuid_bits_needed(
-        (max_logical_processor_ids.next_power_of_two() / smt_max_cores_for_package) - 1,
-    );
-    let smt_select_mask = !(u8::max_value() << smt_mask_width);
-    let core_mask_width = cpuid_bits_needed(smt_max_cores_for_package - 1);
-    let core_only_select_mask =
-        (!(u8::max_value() << (core_mask_width + smt_mask_width))) ^ smt_select_mask;
-    let pkg_select_mask = u8::max_value() << (core_mask_width + smt_mask_width);
-
-    let xapic_id = cpuid
-        .get_feature_info()
-        .map_or(0, |f| f.initial_local_apic_id());
-
-    let smt_id = xapic_id & smt_select_mask;
-    let core_id = (xapic_id & core_only_select_mask) >> smt_mask_width;
-    let pkg_id = (xapic_id & pkg_select_mask) >> (core_mask_width + smt_mask_width);
-
-    println!(
-        "APIC#{} (pkg: {}, core: {}, smt: {})",
-        xapic_id, pkg_id, core_id, smt_id
-    );
-
-    Ok((
-        pkg_id as u32,
-        core_id as u32,
-        smt_id as u32,
-        vendor,
-        model.to_string(),
-    ))
-}
-
-// Insert CPU info into the main vector
 fn insert_cpu_info(
     cpus: &mut Vec<Cpu>,
     affinity: GroupAffinity,
     info: (u32, u32, u32, Vendor, String),
     driver: &Arc<KernelDriver>,
 ) {
-    let (pkg_id, core_id, smt_id, vendor, model) = info;
+    let (package_id, core_id, smt_id, vendor, model) = info;
 
-    if let Some(cpu) = cpus.iter_mut().find(|c| c.package_id == pkg_id) {
-        // update cpu.affinity if this one is "lower"
+    if let Some(cpu) = cpus.iter_mut().find(|c| c.package_id == package_id) {
         if is_lower_affinity(&affinity, &cpu.affinity) {
             cpu.affinity = affinity.clone();
         }
 
-        // find an existing Core inside the CPU
-        if let Some(core_entry) = cpu.cores.iter_mut().find(|c| c.core_id == core_id) {
-            // add a new Thread to an existing Core
-            core_entry.threads.push(Thread {
-                backend: cpu.backend.clone(),
-                affinity,
-                thread_id: smt_id,
-            });
+        if let Some(core) = cpu.cores.iter_mut().find(|c| c.core_id == core_id) {
+            core.threads
+                .push(Thread::new(smt_id, affinity, cpu.backend.clone()));
         } else {
-            // create a new Core with its first Thread
-            cpu.cores.push(Core {
-                backend: cpu.backend.clone(),
-                core_id,
-                threads: vec![Thread {
-                    backend: cpu.backend.clone(),
-                    affinity,
-                    thread_id: smt_id,
-                }],
-            });
+            let mut core = Core::new(core_id, cpu.backend.clone());
+            core.threads
+                .push(Thread::new(smt_id, affinity, cpu.backend.clone()));
+            cpu.cores.push(core);
         }
     } else {
-        // create a new Cpu for this package
         let backend: Arc<dyn CpuBackend + Send + Sync> = match vendor {
             Vendor::Intel => Arc::new(IntelBackend::new(driver.clone())),
             Vendor::Amd => Arc::new(AmdBackend::new(driver.clone())),
             Vendor::Unknown(_) => Arc::new(UnknownBackend::new(driver.clone())),
         };
 
+        let mut core = Core::new(core_id, backend.clone());
+        core.threads
+            .push(Thread::new(smt_id, affinity.clone(), backend.clone()));
+
         cpus.push(Cpu {
-            backend: backend.clone(),
-            package_id: pkg_id,
+            backend,
+            package_id,
             vendor,
             model,
-            affinity: affinity.clone(), // first affinity seen
-            cores: vec![Core {
-                backend: backend.clone(),
-                core_id,
-                threads: vec![Thread {
-                    backend: backend.clone(),
-                    affinity,
-                    thread_id: smt_id,
-                }],
-            }],
+            affinity,
+            cores: vec![core],
         });
     }
 }
 
-/// Decide if `a` is "lower" than `b` by group first, then by mask
 fn is_lower_affinity(a: &GroupAffinity, b: &GroupAffinity) -> bool {
     (a.group < b.group) || (a.group == b.group && a.mask < b.mask)
 }

--- a/src/system/cpu/group_affinity/group_affinity.rs
+++ b/src/system/cpu/group_affinity/group_affinity.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone)]
+pub struct GroupAffinity {
+    pub mask: usize,
+    pub group: u16,
+}

--- a/src/system/cpu/group_affinity/mod.rs
+++ b/src/system/cpu/group_affinity/mod.rs
@@ -1,0 +1,7 @@
+pub mod group_affinity;
+pub mod system;
+pub mod thread;
+
+pub use group_affinity::GroupAffinity;
+pub use system::get_all_group_affinities;
+pub use thread::{run_on_all_affinities, with_affinity};

--- a/src/system/cpu/group_affinity/system.rs
+++ b/src/system/cpu/group_affinity/system.rs
@@ -1,0 +1,69 @@
+use windows::Win32::{
+    Foundation::ERROR_INSUFFICIENT_BUFFER,
+    System::SystemInformation::{
+        GetLogicalProcessorInformationEx, RelationProcessorCore,
+        SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+    },
+};
+
+use crate::system::cpu::group_affinity::GroupAffinity;
+
+pub fn get_all_group_affinities() -> Result<Vec<GroupAffinity>, String> {
+    unsafe {
+        // First call: get required buffer size
+        let mut return_length: u32 = 0;
+        if let Err(e) =
+            GetLogicalProcessorInformationEx(RelationProcessorCore, None, &mut return_length)
+        {
+            let raw_win32 = e.code().0 & 0xFFFF; // extract original Win32 error code
+            if raw_win32 != ERROR_INSUFFICIENT_BUFFER.0 as i32 {
+                return Err(format!("Unexpected error getting buffer size: {:?}", e));
+            }
+        }
+
+        // Allocate buffer
+        let mut buffer = vec![0u8; return_length as usize];
+
+        // Second call: fill buffer
+        GetLogicalProcessorInformationEx(
+            RelationProcessorCore,
+            Some(buffer.as_mut_ptr() as *mut SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX),
+            &mut return_length,
+        )
+        .map_err(|e| format!("Failed to get processor info: {:?}", e))?;
+
+        let mut offset = 0;
+        let mut affinities = Vec::new();
+
+        while offset < return_length as usize {
+            let info_ptr =
+                buffer.as_ptr().add(offset) as *const SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
+            let info = &*info_ptr;
+
+            if info.Relationship == RelationProcessorCore {
+                let processor = &info.Anonymous.Processor;
+
+                for group_index in 0..processor.GroupCount as usize {
+                    let group_affinity = &processor.GroupMask[group_index];
+                    let mut mask = group_affinity.Mask;
+
+                    while mask != 0 {
+                        let lsb = mask.trailing_zeros();
+                        let single_mask = 1 << lsb;
+                        affinities.push(GroupAffinity {
+                            mask: single_mask as usize,
+                            group: group_affinity.Group,
+                        });
+                        mask &= !single_mask;
+                    }
+                }
+            }
+
+            // println!("info.Size: {}", info.Size);
+
+            offset += info.Size as usize;
+        }
+
+        Ok(affinities)
+    }
+}

--- a/src/system/cpu/group_affinity/thread.rs
+++ b/src/system/cpu/group_affinity/thread.rs
@@ -1,21 +1,11 @@
 use std::thread;
 
-use windows::Win32::{
-    Foundation::ERROR_INSUFFICIENT_BUFFER,
-    System::{
-        SystemInformation::{
-            GetLogicalProcessorInformationEx, RelationProcessorCore, GROUP_AFFINITY,
-            SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
-        },
-        Threading::{GetCurrentThread, GetThreadGroupAffinity, SetThreadGroupAffinity},
-    },
+use windows::Win32::System::{
+    SystemInformation::GROUP_AFFINITY,
+    Threading::{GetCurrentThread, GetThreadGroupAffinity, SetThreadGroupAffinity},
 };
 
-#[derive(Debug, Clone)]
-pub struct GroupAffinity {
-    pub mask: usize,
-    pub group: u16,
-}
+use crate::system::cpu::group_affinity::GroupAffinity;
 
 /// Set thread affinity temporarily, run the closure, restore old affinity
 pub fn with_affinity<F, R>(aff: &GroupAffinity, f: F) -> Result<R, String>
@@ -67,7 +57,6 @@ where
         if !GetThreadGroupAffinity(thread, &mut prev).as_bool() {
             return Err("Failed to get previous thread affinity".into());
         }
-        println!("prev {:?}", prev);
 
         // Spawn threads for each affinity
         let handles: Vec<_> = affinities
@@ -101,65 +90,5 @@ where
         }
 
         Ok(results)
-    }
-}
-
-pub fn get_all_group_affinities() -> Result<Vec<GroupAffinity>, String> {
-    unsafe {
-        // First call: get required buffer size
-        let mut return_length: u32 = 0;
-        if let Err(e) =
-            GetLogicalProcessorInformationEx(RelationProcessorCore, None, &mut return_length)
-        {
-            let raw_win32 = e.code().0 & 0xFFFF; // extract original Win32 error code
-            if raw_win32 != ERROR_INSUFFICIENT_BUFFER.0 as i32 {
-                return Err(format!("Unexpected error getting buffer size: {:?}", e));
-            }
-        }
-
-        // Allocate buffer
-        let mut buffer = vec![0u8; return_length as usize];
-
-        // Second call: fill buffer
-        GetLogicalProcessorInformationEx(
-            RelationProcessorCore,
-            Some(buffer.as_mut_ptr() as *mut SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX),
-            &mut return_length,
-        )
-        .map_err(|e| format!("Failed to get processor info: {:?}", e))?;
-
-        let mut offset = 0;
-        let mut affinities = Vec::new();
-
-        while offset < return_length as usize {
-            let info_ptr =
-                buffer.as_ptr().add(offset) as *const SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
-            let info = &*info_ptr;
-
-            if info.Relationship == RelationProcessorCore {
-                let processor = &info.Anonymous.Processor;
-
-                for group_index in 0..processor.GroupCount as usize {
-                    let group_affinity = &processor.GroupMask[group_index];
-                    let mut mask = group_affinity.Mask;
-
-                    while mask != 0 {
-                        let lsb = mask.trailing_zeros();
-                        let smask = 1 << lsb;
-                        affinities.push(GroupAffinity {
-                            mask: smask as usize,
-                            group: group_affinity.Group,
-                        });
-                        mask &= !smask;
-                    }
-                }
-            }
-
-            // println!("info.Size: {}", info.Size);
-
-            offset += info.Size as usize;
-        }
-
-        Ok(affinities)
     }
 }

--- a/src/system/cpu/mod.rs
+++ b/src/system/cpu/mod.rs
@@ -1,2 +1,9 @@
 mod backend;
+mod core;
 pub mod cpu;
+pub mod group_affinity;
+mod thread;
+mod topology;
+mod vendor;
+
+// pub use cpu::;

--- a/src/system/cpu/thread.rs
+++ b/src/system/cpu/thread.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use crate::system::cpu::{backend::CpuBackend, group_affinity::GroupAffinity};
+
+pub struct Thread {
+    pub thread_id: u32,
+    pub affinity: GroupAffinity,
+    backend: Arc<dyn CpuBackend + Send + Sync>,
+}
+
+impl Thread {
+    /// Constructor for Thread
+    pub fn new(
+        thread_id: u32,
+        affinity: GroupAffinity,
+        backend: Arc<dyn CpuBackend + Send + Sync>,
+    ) -> Self {
+        Self {
+            thread_id,
+            affinity,
+            backend,
+        }
+    }
+}
+
+impl std::fmt::Debug for Thread {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Thread")
+            .field("thread_id", &self.thread_id)
+            .field("affinity", &self.affinity)
+            .finish()
+    }
+}

--- a/src/system/cpu/topology.rs
+++ b/src/system/cpu/topology.rs
@@ -1,0 +1,115 @@
+use raw_cpuid::{CpuId, CpuIdReader, ExtendedTopologyLevel, TopologyType};
+
+use crate::system::cpu::vendor::Vendor;
+
+fn cpuid_bits_needed(count: u8) -> u8 {
+    let mut mask: u8 = 0x80;
+    let mut cnt: u8 = 8;
+
+    while (cnt > 0) && ((mask & count) != mask) {
+        mask >>= 1;
+        cnt -= 1;
+    }
+
+    cnt
+}
+
+// Handle extended topology (x2APIC)
+pub fn get_topology_info(
+    topoiter: impl Iterator<Item = ExtendedTopologyLevel>,
+    vendor: Vendor,
+    model: &str,
+) -> Result<(u32, u32, u32, Vendor, String), String> {
+    let topology: Vec<ExtendedTopologyLevel> = topoiter.collect();
+
+    let mut smt_x2apic_shift = 0;
+    let mut core_x2apic_shift = 0;
+
+    for level in &topology {
+        match level.level_type() {
+            TopologyType::SMT => smt_x2apic_shift = level.shift_right_for_next_apic_id(),
+            TopologyType::Core => core_x2apic_shift = level.shift_right_for_next_apic_id(),
+            _ => return Err("Unsupported topology level type".to_string()),
+        }
+    }
+
+    // Use the first element of the topology vector for x2apic_id
+    let x2apic_id = topology.first().map(|l| l.x2apic_id()).unwrap_or(0);
+
+    let smt_select_mask = !(u32::max_value() << smt_x2apic_shift);
+    let core_select_mask = (!((u32::max_value()) << core_x2apic_shift)) ^ smt_select_mask;
+    let pkg_select_mask = u32::max_value() << core_x2apic_shift;
+
+    let smt_id = x2apic_id & smt_select_mask;
+    let core_id = (x2apic_id & core_select_mask) >> smt_x2apic_shift;
+    let pkg_id = (x2apic_id & pkg_select_mask) >> core_x2apic_shift;
+
+    // println!(
+    //     "x2APIC#{} (pkg: {}, core: {}, smt: {})",
+    //     x2apic_id, pkg_id, core_id, smt_id
+    // );
+
+    Ok((pkg_id, core_id, smt_id, vendor, model.to_string()))
+}
+
+// Handle legacy APIC topology
+pub fn get_legacy_info<R: CpuIdReader>(
+    cpuid: &CpuId<R>,
+    vendor: Vendor,
+    model: &str,
+) -> Result<(u32, u32, u32, Vendor, String), String> {
+    let (max_logical_processor_ids, smt_max_cores_for_package) = match vendor {
+        Vendor::Intel => {
+            let cparams = cpuid
+                .get_cache_parameters()
+                .ok_or("Intel CPU: missing cache parameters")?;
+            let max_logical = cpuid
+                .get_feature_info()
+                .map(|f| f.max_logical_processor_ids())
+                .unwrap_or(1);
+            let smt_cores = cparams
+                .into_iter()
+                .next()
+                .ok_or("Intel CPU: no cache parameter entries")?
+                .max_cores_for_package() as u8;
+            (max_logical as u8, smt_cores)
+        }
+        Vendor::Amd => {
+            let info = cpuid
+                .get_processor_capacity_feature_info()
+                .ok_or("AMD CPU: missing processor capacity info")?;
+            (info.num_phys_threads() as u8, info.apic_id_size() as u8)
+        }
+        Vendor::Unknown(_) => return Err("Unsupported CPU vendor".to_string()),
+    };
+
+    let smt_mask_width = cpuid_bits_needed(
+        (max_logical_processor_ids.next_power_of_two() / smt_max_cores_for_package) - 1,
+    );
+    let smt_select_mask = !(u8::max_value() << smt_mask_width);
+    let core_mask_width = cpuid_bits_needed(smt_max_cores_for_package - 1);
+    let core_only_select_mask =
+        (!(u8::max_value() << (core_mask_width + smt_mask_width))) ^ smt_select_mask;
+    let pkg_select_mask = u8::max_value() << (core_mask_width + smt_mask_width);
+
+    let xapic_id = cpuid
+        .get_feature_info()
+        .map_or(0, |f| f.initial_local_apic_id());
+
+    let smt_id = xapic_id & smt_select_mask;
+    let core_id = (xapic_id & core_only_select_mask) >> smt_mask_width;
+    let pkg_id = (xapic_id & pkg_select_mask) >> (core_mask_width + smt_mask_width);
+
+    // println!(
+    //     "APIC#{} (pkg: {}, core: {}, smt: {})",
+    //     xapic_id, pkg_id, core_id, smt_id
+    // );
+
+    Ok((
+        pkg_id as u32,
+        core_id as u32,
+        smt_id as u32,
+        vendor,
+        model.to_string(),
+    ))
+}

--- a/src/system/cpu/vendor.rs
+++ b/src/system/cpu/vendor.rs
@@ -1,0 +1,20 @@
+use raw_cpuid::{CpuId, CpuIdReader};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Vendor {
+    Intel,
+    Amd,
+    Unknown(Option<String>),
+}
+
+// Extract vendor from CPUID
+pub fn get_vendor<R: CpuIdReader>(cpuid: &CpuId<R>) -> Vendor {
+    cpuid
+        .get_vendor_info()
+        .map(|v| match v.as_str() {
+            "GenuineIntel" => Vendor::Intel,
+            "AuthenticAMD" | "HygonGenuine" => Vendor::Amd,
+            name => Vendor::Unknown(Some(name.to_owned())),
+        })
+        .unwrap_or(Vendor::Unknown(None))
+}

--- a/src/system/kernal_driver.rs
+++ b/src/system/kernal_driver.rs
@@ -23,8 +23,8 @@ use windows_service::{
     service_manager::{ServiceManager, ServiceManagerAccess},
 };
 
-use crate::system::affinity::with_affinity;
-use crate::system::affinity::GroupAffinity;
+use crate::system::cpu::group_affinity::with_affinity;
+use crate::system::cpu::group_affinity::GroupAffinity;
 use crate::system::ioctl::IOCTL;
 
 /// IO Method

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,4 +1,3 @@
-mod affinity;
 mod cpu;
 mod ioctl;
 mod kernal_driver;


### PR DESCRIPTION
This PR refactors the CPU detection code to improve structure:
- Split CPU detection and affinity handling into separate, smaller modules.
- Replaced core_affinity with Windows-native group affinity handling.
- Supports multi-CPU and multi-group systems.

Not fully satisfied with the structure yet, but it is cleaner and more maintainable than the previous single large file.

Closes #1 